### PR TITLE
feat(RadarChart): setViewBox 

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ const defaultOptions = {
   captionMargin: 10,
   dots: false, // show dots?
   zoomDistance: 1.2, // where on the axes are the captions?
+  setViewBox: (options) => `-${options.captionMargin} 0 ${options.size + options.captionMargin * 2} ${options.size}`, // custom viewBox ?
   smoothing: noSmoothing, // shape smoothing function
   axisProps: () => ({ className: 'axis' }),
   scaleProps: () => ({ className: 'scale', fill: 'none' }),
@@ -295,6 +296,7 @@ const defaultOptions = {
 | dots | *true*/*false* show dots |
 | zoomDistance | the distance of the zoom: 0.2 = closest |
 | smoothing | the smoothing function |
+| setViewBox | a function that take *options*' object as argument and returns viewBox as a string. ViewBox will be added to the *svg*|
 | axisProps | a function that take the *current caption name* as arguments and returns an object. All the property will be added to the *axis svg component*|
 | scaleProps | a function that take the *value of the scales* as arguments and returns an object. All the property will be added to the *scale svg component*|
 | shapeProps | a function that take the *meta of the data* as arguments and returns an object. All the property will be added to the *shape svg component*|

--- a/src/lib/components/RadarChart.js
+++ b/src/lib/components/RadarChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import '../radar.css';
 import radar from './radar';
 
-import '../radar.css';
 
 const noSmoothing = points => {
   let d = 'M' + points[0][0].toFixed(4) + ',' + points[0][1].toFixed(4);
@@ -10,6 +10,8 @@ const noSmoothing = points => {
   }
   return d + 'z';
 };
+
+const setViewBox = (options) => `-${options.captionMargin} 0 ${options.size + options.captionMargin * 2} ${options.size}`
 
 const defaultOptions = {
   size: 300,
@@ -20,6 +22,7 @@ const defaultOptions = {
   zoomDistance: 1.2, // where on the axes are the captions?
   smoothing: noSmoothing, // shape smoothing function
   captionMargin: 10,
+  setViewBox,
   axisProps: () => ({ className: 'axis' }),
   scaleProps: () => ({ className: 'scale', fill: 'none' }),
   shapeProps: () => ({ className: 'shape' }),
@@ -34,22 +37,26 @@ const defaultOptions = {
   })
 };
 
-const RadarChart = props => {
-  const { data, captions, options } = props;
-  let { size } = props;
-  if (!size) {
-    size = defaultOptions.size;
-  }
-  const chartOptions = { ...defaultOptions, ...options, size };
-  const chart = radar(captions, data, chartOptions);
+const RadarChart = (props) => {
+  const { data, captions, options, size = defaultOptions.size } = props;
+
+  const chartOptions = {
+    ...defaultOptions,
+    ...options,
+    size,
+  };
+
+  const { setViewBox } = chartOptions;
   const captionMargin = chartOptions.captionMargin;
+  const chart = radar(captions, data, chartOptions);
+
   return (
     <svg
       version="1"
       xmlns="http://www.w3.org/2000/svg"
       width={size}
       height={size}
-      viewBox={`-${captionMargin} 0 ${size + captionMargin * 2} ${size}`}
+      viewBox={setViewBox(chartOptions)}
     >
       {chart}
     </svg>

--- a/src/lib/components/RadarChart.js
+++ b/src/lib/components/RadarChart.js
@@ -47,7 +47,6 @@ const RadarChart = (props) => {
   };
 
   const { setViewBox } = chartOptions;
-  const captionMargin = chartOptions.captionMargin;
   const chart = radar(captions, data, chartOptions);
 
   return (

--- a/src/lib/components/RadarChart.test.js
+++ b/src/lib/components/RadarChart.test.js
@@ -219,3 +219,34 @@ it('RadarChart renders with 2 dots', () => {
 
   expect(div.querySelectorAll('.testDot').length).toBe(2);
 });
+
+it('render with custom viewBox', () => {
+  const div = document.createElement('div');
+  const viewBox = '0 0 500 500';
+  const setViewBox = () => viewBox;
+  const data = [
+    {
+      data: {
+        battery: 0.7,
+        speed: 0.67
+      },
+      meta: {}
+    }
+  ];
+
+  const captions = {
+    battery: 'Battery Capacity',
+    speed: 'Speed'
+  };
+
+  const options = {
+    setViewBox
+  }
+
+  ReactDOM.render(
+    <RadarChart captions={captions} data={data} options={options} />,
+    div
+  );
+
+  expect(div.querySelectorAll(`svg[viewBox='${viewBox}']`).length).toBe(1);
+})


### PR DESCRIPTION
When we have a long text as caption, caption is trunked
With this PR, we can set the viewBox with a function `setViewBox` passed in options
![before](https://goo.gl/1umPvu)

With a customViewBox

![after](https://goo.gl/JYtzVs)

Thanks for this package